### PR TITLE
Fixed the scrict warning.. 

### DIFF
--- a/Model/Behavior/SluggableBehavior.php
+++ b/Model/Behavior/SluggableBehavior.php
@@ -52,7 +52,7 @@ class SluggableBehavior extends ModelBehavior
      * @param array $settings Settings to override for model.
      * @access public
      */
-    function setup(&$Model, $settings = array())
+    public function setup(Model $Model, $settings = array())
     {
         $default = array('label' => array('title'), 'slug' => 'slug', 'separator' => '-', 'length' => 100, 'overwrite' => false, 'translation' => null);
 
@@ -82,8 +82,7 @@ class SluggableBehavior extends ModelBehavior
      * @return boolean true if save should proceed, false otherwise
      * @access public
      */
-    function beforeSave(&$Model)
-    {
+	public function beforeSave(Model $Model, $options = array()) {
         $return = parent::beforeSave($Model);
 
         // Make label fields an array
@@ -364,4 +363,3 @@ class SluggableBehavior extends ModelBehavior
     }
 }
 
-?>


### PR DESCRIPTION
Fixed following strict warnings

Strict (2048): Declaration of SluggableBehavior::setup() should be compatible with ModelBehavior::setup(Model $model, $config = Array) [APP\Model\Behavior\SluggableBehavior.php, line 23]

Strict (2048): Declaration of SluggableBehavior::beforeSave() should be compatible with ModelBehavior::beforeSave(Model $model) [APP\Model\Behavior\SluggableBehavior.php, line 23]
